### PR TITLE
- Complete Refactoring of the Ghidra block processing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# library for IDE
+lib/*

--- a/serializer/Serializer.java
+++ b/serializer/Serializer.java
@@ -8,6 +8,7 @@ import com.google.gson.*;
 import term.Project;
 import term.Sub;
 import term.Jmp;
+import term.Def;
 
 
 public class Serializer {
@@ -45,7 +46,10 @@ public class Serializer {
                 if (field.getDeclaringClass() == Sub.class && field.getName().equals("addresses")) {
                     return true;
                 }
-                if (field.getDeclaringClass() == Jmp.class && field.getName().equals("type")) {
+                if (field.getDeclaringClass() == Jmp.class && (field.getName().equals("type") || field.getName().equals("pcodeIndex"))) {
+                    return true;
+                }
+                if (field.getDeclaringClass() == Def.class && field.getName().equals("pcodeIndex")) {
                     return true;
                 }
                 return false;

--- a/term/Blk.java
+++ b/term/Blk.java
@@ -11,6 +11,8 @@ public class Blk {
     private ArrayList<Term<Jmp>> jmps;
 
     public Blk() {
+        this.setDefs(new ArrayList<Term<Def>>());
+        this.setJmps(new ArrayList<Term<Jmp>>());
     }
 
     public Blk(ArrayList<Term<Def>> defs, ArrayList<Term<Jmp>> jmps) {
@@ -40,6 +42,10 @@ public class Blk {
 
     public void addJmp(Term<Jmp> jmp) {
         this.jmps.add(jmp);
+    }
+
+    public void addMultipleDefs(ArrayList<Term<Def>> defs) {
+        this.defs.addAll(defs);
     }
 
 

--- a/term/Def.java
+++ b/term/Def.java
@@ -11,17 +11,21 @@ public class Def {
     private Variable lhs;
     @SerializedName("rhs")
     private Expression rhs;
+    @SerializedName("pcode_index")
+    private int pcodeIndex;
 
     public Def() {
     }
 
-    public Def(Expression rhs) {
+    public Def(Expression rhs, int pcodeIndex) {
         this.setRhs(rhs);
+        this.setPcodeIndex(pcodeIndex);
     }
 
-    public Def(Variable lhs, Expression rhs) {
+    public Def(Variable lhs, Expression rhs, int pcodeIndex) {
         this.setLhs(lhs);
         this.setRhs(rhs);
+        this.setPcodeIndex(pcodeIndex);
     }
 
     public Variable getLhs() {
@@ -38,5 +42,13 @@ public class Def {
 
     public void setRhs(Expression rhs) {
         this.rhs = rhs;
+    }
+
+    public int getPcodeIndex() {
+        return pcodeIndex;
+    }
+
+    public void setPcodeIndex(int pcodeIndex) {
+        this.pcodeIndex = pcodeIndex;
     }
 }

--- a/term/Jmp.java
+++ b/term/Jmp.java
@@ -17,27 +17,32 @@ public class Jmp {
     private Call call;
     @SerializedName("condition")
     private Variable condition;
+    @SerializedName("pcode_index")
+    private int pcodeIndex;
 
     public Jmp() {
     }
 
-    public Jmp(ExecutionType.JmpType type, String mnemonic, Label goto_) {
+    public Jmp(ExecutionType.JmpType type, String mnemonic, Label goto_, int pcodeIndex) {
         this.setType(type);
         this.setMnemonic(mnemonic);
         this.setGoto_(goto_);
+        this.setPcodeIndex(pcodeIndex);
     }
 
-    public Jmp(ExecutionType.JmpType type, String mnemonic, Call call) {
+    public Jmp(ExecutionType.JmpType type, String mnemonic, Call call, int pcodeIndex) {
         this.setType(type);
         this.setMnemonic(mnemonic);
         this.setCall(call);
+        this.setPcodeIndex(pcodeIndex);
     }
 
-    public Jmp(ExecutionType.JmpType type, String mnemonic, Label goto_, Variable condition) {
+    public Jmp(ExecutionType.JmpType type, String mnemonic, Label goto_, Variable condition, int pcodeIndex) {
         this.setType(type);
         this.setMnemonic(mnemonic);
         this.setGoto_(goto_);
         this.setCondition(condition);
+        this.setPcodeIndex(pcodeIndex);
     }
 
     public ExecutionType.JmpType getType() {
@@ -78,6 +83,14 @@ public class Jmp {
 
     public void setGoto_(Label goto_) {
         this.goto_ = goto_;
+    }
+
+    public int getPcodeIndex() {
+        return pcodeIndex;
+    }
+
+    public void setPcodeIndex(int pcodeIndex) {
+        this.pcodeIndex = pcodeIndex;
     }
 
 }

--- a/term/Program.java
+++ b/term/Program.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import com.google.gson.annotations.SerializedName;
 
 import symbol.ExternSymbol;
-import term.Tid;
 
 public class Program {
 


### PR DESCRIPTION
   +  Now jumps inside pcode groups are considered and split into seperate groups.
   +  Artificial jumps have been added to split groups
- Size of stack pointer register now in bytes instead of bits
- Copy Store translation nows puts inputs into input1 and input2
- Bug fix where program crashed when accessing non-existent references to thunk functions